### PR TITLE
Scrolling on mobile devices resets timer for returning to voting screen

### DIFF
--- a/src/app/serendipitous-view/serendipitous-view.component.html
+++ b/src/app/serendipitous-view/serendipitous-view.component.html
@@ -1,5 +1,5 @@
 
-<div *ngIf="showDetail" class="detailContainer Center-Container" (click)="resetDetailTimer(); resetVotingResultsTimer()">
+<div *ngIf="showDetail" class="detailContainer Center-Container" (click)="resetDetailTimer(); resetVotingResultsTimer()" (touchmove)="resetVotingResultsTimer()">
 
   <div *ngIf="listingService.grouping.displayMode === 'Serendipitous'">
     <!--p class="text-mainHeading">#framtidscampus*</p-->


### PR DESCRIPTION
in case people want to scroll through results and read them at the same time